### PR TITLE
ADD - Way to pass custom publicKeys to some of our samples

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,22 @@
                                         <input type="color" class="form-control" id="primaryForegroundColor"
                                                pattern="#[A-Fa-f0-9]{6}">
                                     </div>
+                                    <div class="mb-3">
+                                        <label for="optionalAppName" class="form-label">Optional App Name</label>
+                                        <input type="text" class="form-control" id="optionalAppName"
+                                               placeholder="Enter the app name">
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="optionalAndroidPublicKey" class="form-label">Optional Android Public Key</label>
+                                        <input type="text" class="form-control" id="optionalAndroidPublicKey"
+                                               placeholder="Enter the Android publicKey">
+                                    </div>
+                                    <div class="mb-3">
+                                        <label for="optionaliOSPublicKey" class="form-label">Optional iOS Public Key</label>
+                                        <input type="text" class="form-control" id="optionaliOSPublicKey"
+                                               placeholder="Enter the iOS publicKey">
+                                        <small class="form-text text-muted" style="height: 400px">Note: Custom app publicKeys might only work on some samples.</small>
+                                    </div>
                                 </form>
                             </div>
                         </div>

--- a/js/script.js
+++ b/js/script.js
@@ -8,6 +8,9 @@ const logoInput = document.getElementById("logoUpload");
 const primaryColorInput = document.getElementById("primaryColor");
 const primaryColorDarkInput = document.getElementById("primaryColorDark");
 const primaryForegroundColorInput = document.getElementById("primaryForegroundColor");
+const optionalAppNameInput = document.getElementById("optionalAppName");
+const optionalAndroidPublicKeyInput = document.getElementById("optionalAndroidPublicKey");
+const optionaliOSPublicKeyInput = document.getElementById("optionaliOSPublicKey");
 const searchFilterInput = document.getElementById("filter-input");
 const cards = Array.from(document.querySelectorAll(".card"));
 const useCaseContent = document.getElementById('useCaseContent');
@@ -57,6 +60,27 @@ function updateLogo() {
     }
     updateAllQueryStrings((url) => {
         updateQueryStringParameter(url, "logo", logoValue);
+    });
+}
+
+function updateOptionalAndroidPublicKey() {
+    const optionalAndroidPublicKey = optionalAndroidPublicKeyInput.value;
+    updateAllQueryStrings((url) => {
+        updateQueryStringParameter(url, "optionalAndroidPublicKey", optionalAndroidPublicKey);
+    });
+}
+
+function updateOptionaliOSPublicKey() {
+    const optionaliOSPublicKey = optionaliOSPublicKeyInput.value;
+    updateAllQueryStrings((url) => {
+        updateQueryStringParameter(url, "optionaliOSPublicKey", optionaliOSPublicKey);
+    });
+}
+
+function updateOptionalAppName() {
+    const appName = optionalAppNameInput.value;
+    updateAllQueryStrings((url) => {
+        updateQueryStringParameter(url, "optionalAppName", appName);
     });
 }
 
@@ -135,6 +159,9 @@ const updateInputsFromQueryParameters = () => {
     updateValueIfQueryParameterExists(primaryColorInput, 'primaryColor', updatePrimaryColor);
     updateValueIfQueryParameterExists(primaryColorDarkInput, 'primaryColorDark', updatePrimaryColorDark);
     updateValueIfQueryParameterExists(primaryForegroundColorInput, 'primaryForegroundColor', updatePrimaryForegroundColor);
+    updateValueIfQueryParameterExists(optionalAppNameInput, 'optionalAppName', updateOptionalAppName);
+    updateValueIfQueryParameterExists(optionalAndroidPublicKeyInput, 'optionalAndroidPublicKey', updateOptionalAndroidPublicKey);
+    updateValueIfQueryParameterExists(optionaliOSPublicKeyInput, 'optionaliOSPublicKey', updateOptionaliOSPublicKey);
     updateValueIfQueryParameterExists(searchFilterInput, 'search', performFilter);
     useCaseCheckboxInputs.forEach(input => {
         updateValueIfQueryParameterExists(input, 'usecase', performFilter);
@@ -220,6 +247,9 @@ logoInput.addEventListener("change", updateLogo);
 primaryColorInput.addEventListener("change", updatePrimaryColor);
 primaryColorDarkInput.addEventListener("change", updatePrimaryColorDark);
 primaryForegroundColorInput.addEventListener("change", updatePrimaryForegroundColor);
+optionalAppNameInput.addEventListener("change", updateOptionalAppName);
+optionalAndroidPublicKeyInput.addEventListener("change", updateOptionalAndroidPublicKey);
+optionaliOSPublicKeyInput.addEventListener("change", updateOptionaliOSPublicKey);
 useCaseCheckboxInputs.forEach(input => {
     input.addEventListener('change', performFilter);
 });

--- a/product_launch_page_variant_1/js/sample_styling.js
+++ b/product_launch_page_variant_1/js/sample_styling.js
@@ -26,7 +26,42 @@ const updateCSSVariable = (variableName, queryParamName) => {
     }
 };
 
+/**
+ * Updates the config products to match the apps passed in the query parameters.
+ */
+function updateConfigProducts() {
+    const optionalAndroidPublicKey = queryParams.get('optionalAndroidPublicKey');
+    const optionaliOSPublicKey = queryParams.get('optionaliOSPublicKey');
+    const optionalAppName = queryParams.get('optionalAppName');
+
+    if (!optionalAndroidPublicKey && !optionaliOSPublicKey) {
+        return;
+    }
+
+    let demoProduct = {
+        name: optionalAppName ?? "Demo App"
+    };
+
+    if (optionaliOSPublicKey) {
+        demoProduct.ios = {
+            publicKey: optionaliOSPublicKey,
+            device: "iphone14pro",
+        };
+    }
+
+    if (optionalAndroidPublicKey) {
+        demoProduct.android = {
+            publicKey: optionalAndroidPublicKey,
+            device: "pixel6",
+        };
+    }
+
+    config.products = [];
+    config.products.push(demoProduct);
+}
+
 document.addEventListener('DOMContentLoaded', updateLogoFromQueryParam);
 updateCSSVariable('--bs-primary', 'primaryColor');
 updateCSSVariable('--bs-primary-dark', 'primaryColorDark');
 updateCSSVariable('--bs-foreground', 'primaryForegroundColor');
+updateConfigProducts();

--- a/product_launch_page_variant_1/launch.html
+++ b/product_launch_page_variant_1/launch.html
@@ -58,9 +58,9 @@
         integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
         crossorigin="anonymous"></script>
 <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
+<script src="js/config.js"></script>
 <!-- Remove this script in your own implementation - Used for styling the demo experience -->
 <script src="js/sample_styling.js"></script>
-<script src="js/config.js"></script>
 <script src="js/core.js"></script>
 
 </body>

--- a/product_launch_page_variant_2/js/sample_styling.js
+++ b/product_launch_page_variant_2/js/sample_styling.js
@@ -14,6 +14,41 @@ const updateLogoFromQueryParam = () => {
 };
 
 /**
+ * Updates the config products to match the apps passed in the query parameters.
+ */
+function updateConfigProducts() {
+    const optionalAndroidPublicKey = queryParams.get('optionalAndroidPublicKey');
+    const optionaliOSPublicKey = queryParams.get('optionaliOSPublicKey');
+    const optionalAppName = queryParams.get('optionalAppName');
+
+    if (!optionalAndroidPublicKey && !optionaliOSPublicKey) {
+        return;
+    }
+
+    config.products = [];
+
+    if (optionaliOSPublicKey) {
+        const name = optionalAppName + " (iOS)" ?? "iOS Demo App";
+        const product = {
+            name: name,
+            publicKey: optionaliOSPublicKey,
+            device: "iphone15pro",
+        };
+        config.products.push(product);
+    }
+
+    if (optionalAndroidPublicKey) {
+        const name = optionalAppName + " (Android)" ?? "Android Demo App";
+        const product = {
+            name: name,
+            publicKey: optionalAndroidPublicKey,
+            device: "pixel6",
+        };
+        config.products.push(product);
+    }
+}
+
+/**
  * Updates a CSS variable from a query parameter.
  * @param variableName The name of the CSS variable.
  * @param queryParamName The name of the query parameter.
@@ -30,3 +65,4 @@ document.addEventListener('DOMContentLoaded', updateLogoFromQueryParam);
 updateCSSVariable('--bs-primary', 'primaryColor');
 updateCSSVariable('--bs-primary-dark', 'primaryColorDark');
 updateCSSVariable('--bs-foreground', 'primaryForegroundColor');
+updateConfigProducts();

--- a/product_launch_page_variant_2/launch.html
+++ b/product_launch_page_variant_2/launch.html
@@ -47,9 +47,9 @@
         integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
         crossorigin="anonymous"></script>
 <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
+<script src="js/config.js"></script>
 <!-- Remove this script in your own implementation - Used for styling the demo experience -->
 <script src="js/sample_styling.js"></script>
-<script src="js/config.js"></script>
 <script src="js/core.js"></script>
 
 </body>


### PR DESCRIPTION
- Currently only the Product Launch Page variants work
- Pass optional Android and/or iOS publicKeys + app name to get a more personalized experience