### PR TITLE
Show queue screen to demonstrate how to use the queue event

### DIFF
--- a/training_experience/js/core.js
+++ b/training_experience/js/core.js
@@ -4,7 +4,10 @@
 const appetizeIframeName = '#appetize';
 const tutorialActionsContainer = document.getElementById('tutorialActions');
 const tutorialContent = document.getElementById('tutorialContent');
+const queueContent = document.getElementById('queueContent');
 const tutorialSelection = document.getElementById('tutorialSelection');
+const queueContentTitle = document.getElementById('queueContentTitle');
+const queueContentPosition = document.getElementById('queueContentPosition');
 const tutorialContentCloseButton = document.querySelector('#tutorialContent .btn-close');
 const tutorialSteps = document.getElementById('tutorialSteps');
 const successModal = document.getElementById('successModal');
@@ -76,6 +79,12 @@ async function initClient(config) {
         console.log(`Loading client for ${appetizeIframeName}`);
         window.client = await window.appetize.getClient(appetizeIframeName, config);
         console.log('client loaded!');
+        window.client.on('queue', ({ name, position }) => {
+            showElement(queueContent)
+            hideElementWithAnimation(tutorialSelection)
+            queueContentTitle.innerText = name ?? 'Device Queue'
+            queueContentPosition.innerText = position
+        })
         window.client.on("session", async session => {
             console.log('session started!')
             try {
@@ -99,7 +108,9 @@ async function initClient(config) {
  */
 function resetUI() {
     selection.tutorial = null;
-    showAndHideWithAnimation(tutorialSelection, tutorialContent);
+    showElement(tutorialSelection)
+    hideElementWithAnimation(tutorialContent)
+    hideElementWithAnimation(queueContent)
 }
 
 /**
@@ -179,11 +190,13 @@ async function selectTutorial(index, shouldUpdateSession = true) {
     showSpinner(clickedButton);
 
     loadTutorialSteps(tutorial);
-    showAndHideWithAnimation(tutorialContent, tutorialSelection);
 
     if (shouldUpdateSession) {
         await updateSession();
     }
+    showElement(tutorialContent)
+    hideElementWithAnimation(tutorialSelection)
+    hideElementWithAnimation(queueContent)
 
     allButtons.forEach(button => {
         enableButton(button);
@@ -355,29 +368,36 @@ function showSuccessModal(title, description) {
     const bsSuccessModal = new bootstrap.Modal(successModal);
     successModal.querySelector('.modal-title').textContent = title;
     successModal.querySelector('.modal-body').textContent = description;
-    bsSuccessModal.show();
+    bsSuccessModal.showElement();
 
     window.confetti.addConfetti();
 }
 
 /**
- * Shows one element with a fade-in animation and hides another with a fade-out animation.
+ * Shows an html element
  * @param {HTMLElement} showElement The element to show.
- * @param {HTMLElement} hideElement The element to hide.
  */
-function showAndHideWithAnimation(showElement, hideElement) {
-    // Element to show
+function showElement(showElement) {
     showElement.classList.add('show');
     showElement.classList.remove('d-none');
+}
 
-    // Element to hide
-    hideElement.classList.remove('show');
+/**
+ * Hides the element only if visible and apply a fade-out animation.
+ * @param {HTMLElement} hideElement The element to hide.
+ */
+function hideElementWithAnimation(hideElement) {
+    // Only perform the action if the element is shown
+    if (hideElement.classList.contains('show')) {
+        // Element to hide
+        hideElement.classList.remove('show');
 
-    // Add event listener for transitionend event
-    hideElement.addEventListener('transitionend', function handler() {
-        hideElement.removeEventListener('transitionend', handler);
-        hideElement.classList.add('d-none');
-    });
+        // Add event listener for transitionend event
+        hideElement.addEventListener('transitionend', function handler() {
+            hideElement.removeEventListener('transitionend', handler);
+            hideElement.classList.add('d-none');
+        });
+    }
 }
 
 // On Page Load

--- a/training_experience/launch.html
+++ b/training_experience/launch.html
@@ -1,86 +1,91 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="utf-8">
     <title>Appetize Training Experience</title>
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <link href="i/favicon.ico" rel="icon">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+        integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.css" rel="stylesheet">
-    <link href="https://unpkg.com/aos@next/dist/aos.css"
-          rel="stylesheet"/>
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@100;200;300;400;500;600;700;800;900&family=DM+Sans:wght@100;200;300;400;500;600;700;800;900&subset=latin&display=swap"
-          rel="stylesheet"/>
-    <link href="css/styles.css" rel="stylesheet"/>
+    <link href="https://unpkg.com/aos@next/dist/aos.css" rel="stylesheet" />
+    <link
+        href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@100;200;300;400;500;600;700;800;900&family=DM+Sans:wght@100;200;300;400;500;600;700;800;900&subset=latin&display=swap"
+        rel="stylesheet" />
+    <link href="css/styles.css" rel="stylesheet" />
 </head>
 
 <body>
-<section class="py-10 py-lg-20 bg-bg-3 text-center text-md-start">
-    <div class="container">
-        <div class="row align-items-center">
-            <div class="mb-12 mb-md-0 col-12">
-                <img id="frontpage_logo" alt="logo" class="img-fluid mb-6 mt-6 w-25 logo" data-aos="fade-right"
-                     data-aos-delay="150"
-                     src="i/frontpage_logo.png" srcset="i/frontpage_logo@2x.png 2x">
-                <h2 class="mb-6 display-6 ps-8 mt-8" data-aos="fade-right" data-aos-delay="250">
-                    Training Experience
-                </h2>
-            </div>
-            <div id="tutorialSelection" class="fade show">
-                <p class="ps-8" data-aos="fade-right">
-                    Select a training tutorial to start:
-                </p>
-                <div id="tutorialActions" class="row row-cols-1 row-cols-md-3"></div>
-            </div>
-            <div id="tutorialContent" class="fade d-none">
-                <button type="button" class="btn-close float-end" aria-label="Close"></button>
-                <p class="ps-8" data-aos="fade-right">
-                    Start the tutorial by following the instructions below:
-                </p>
-                <div class="row">
-                    <div class="mb-12 mb-md-0 col-md-5 col-xl-5">
-                        <ol id="tutorialSteps" class="list-group list-group-numbered">
-                        </ol>
-                    </div>
-                    <div class="col-md-5 col-lg-6 mt-sm-3 text-center">
-                        <iframe data-aos="fade-in"
-                                height="630px"
-                                id="appetize" style="overflow:hidden;" width="300px">
-                        </iframe>
+    <section class="py-10 py-lg-20 bg-bg-3 text-center text-md-start">
+        <div class="container">
+            <div class="row align-items-center">
+                <div class="mb-12 mb-md-0 col-12">
+                    <img id="frontpage_logo" alt="logo" class="img-fluid mb-6 mt-6 w-25 logo" data-aos="fade-right"
+                        data-aos-delay="150" src="i/frontpage_logo.png" srcset="i/frontpage_logo@2x.png 2x">
+                    <h2 class="mb-6 display-6 ps-8 mt-8" data-aos="fade-right" data-aos-delay="250">
+                        Training Experience
+                    </h2>
+                </div>
+                <div id="tutorialSelection" class="fade show">
+                    <p class="ps-8" data-aos="fade-right">
+                        Select a training tutorial to start:
+                    </p>
+                    <div id="tutorialActions" class="row row-cols-1 row-cols-md-3"></div>
+                </div>
+                <div id="queueContent" class="fade d-none">
+                    <h3 class="mb-3" id="queueContentTitle"></h3>
+                    <p>You've been placed in a queue due to maximum capacity achieved.</p>
+                    <p><b>Your current position : <span id="queueContentPosition"></span></b></p>
+                </div>
+                <div id="tutorialContent" class="fade d-none">
+                    <button type="button" class="btn-close float-end" aria-label="Close"></button>
+                    <p class="ps-8" data-aos="fade-right">
+                        Start the tutorial by following the instructions below:
+                    </p>
+                    <div class="row">
+                        <div class="mb-12 mb-md-0 col-md-5 col-xl-5">
+                            <ol id="tutorialSteps" class="list-group list-group-numbered">
+                            </ol>
+                        </div>
+                        <div class="col-md-5 col-lg-6 mt-sm-3 text-center">
+                            <iframe data-aos="fade-in" height="630px" id="appetize" style="overflow:hidden;"
+                                width="300px">
+                            </iframe>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
-    </div>
-</section>
+    </section>
 
-<div class="modal fade" id="successModal" tabindex="-1" aria-labelledby="successModalLabel" aria-hidden="true">
-    <div class="modal-dialog modal-dialog-centered">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title"></h5>
-                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-            </div>
-            <div class="modal-footer">
-                <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Complete & Exit</button>
+    <div class="modal fade" id="successModal" tabindex="-1" aria-labelledby="successModalLabel" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title"></h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-primary" data-bs-dismiss="modal">Complete & Exit</button>
+                </div>
             </div>
         </div>
     </div>
-</div>
 
-<script src="https://js.appetize.io/embed.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+    <script src="https://js.appetize.io/embed.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
         crossorigin="anonymous"></script>
-<script src="https://unpkg.com/aos@next/dist/aos.js"></script>
-<!-- Remove this script in your own implementation - Used for styling the demo experience -->
-<script src="js/sample_styling.js"></script>
-<script src="js/config.js"></script>
-<script src="js/core.js"></script>
-<script src="https://cdn.jsdelivr.net/npm/js-confetti@latest/dist/js-confetti.browser.js"></script>
+    <script src="https://unpkg.com/aos@next/dist/aos.js"></script>
+    <!-- Remove this script in your own implementation - Used for styling the demo experience -->
+    <script src="js/sample_styling.js"></script>
+    <script src="js/config.js"></script>
+    <script src="js/core.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/js-confetti@latest/dist/js-confetti.browser.js"></script>
 
 </body>
+
 </html>


### PR DESCRIPTION
Show a custom queue screen when the queue event is invoked. A weird behavior that I found is when the user exits the queu this toast always shows up.
<img width="457" alt="image" src="https://github.com/user-attachments/assets/ba84c7ff-12f3-4976-a42f-b52730d552e2">

# Queue screen
<img width="1313" alt="image" src="https://github.com/user-attachments/assets/5a5559b4-4190-4b9f-b07d-7a4a156a3389">


