### PR TITLE
Rename Audio & TalkBack Experience to TalkBack Experience

### DIFF
--- a/audio_talkback_experience/README.md
+++ b/audio_talkback_experience/README.md
@@ -1,4 +1,4 @@
-# Audio & TalkBack Experience
+# TalkBack Experience
 
 This sample page demonstrates how to enable **audio output** and **TalkBack**, Google's
 Android screen reader, on an Appetize session. Both features are Android only.

--- a/audio_talkback_experience/js/core.js
+++ b/audio_talkback_experience/js/core.js
@@ -1,4 +1,4 @@
-// Description: Core functions for the Audio & TalkBack experience.
+// Description: Core functions for the TalkBack experience.
 // Variables
 
 const appetizeIframeName = '#appetize';

--- a/audio_talkback_experience/launch.html
+++ b/audio_talkback_experience/launch.html
@@ -3,7 +3,7 @@
 
 <head>
     <meta charset="utf-8">
-    <title>Appetize Audio &amp; TalkBack Experience</title>
+    <title>Appetize TalkBack Experience</title>
     <meta content="width=device-width, initial-scale=1" name="viewport">
     <link href="i/favicon-32.png" rel="icon">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
@@ -39,7 +39,7 @@
                 <img alt="logo" class="img-fluid mb-6 mt-6 w-50 logo" data-aos="fade-right" data-aos-delay="150"
                      id="frontpage_logo" src="i/frontpage_logo.svg">
                 <h2 class="mb-6 display-5 ps-8 mt-8" data-aos="fade-right" data-aos-delay="250">
-                    Audio &amp; TalkBack Experience
+                    TalkBack Experience
                 </h2>
                 <p class="ps-8" data-aos="fade-right">
                     Appetize now supports audio output and Google's TalkBack screen reader on Android.


### PR DESCRIPTION
## Summary
Renames the sample's branded title from **Audio & TalkBack Experience** to **TalkBack Experience** in the `audio_talkback_experience` sample.

Changes are limited to the experience name/title; audio *feature* descriptions and functionality are unchanged.

- `README.md`: heading
- `launch.html`: page `<title>` and hero heading
- `js/core.js`: file description comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)