### PR TITLE
TalkBack experience: always-on audio/TalkBack, auto-start, keyboard nav

### DIFF
--- a/audio_talkback_experience/README.md
+++ b/audio_talkback_experience/README.md
@@ -13,10 +13,11 @@ via the start-time `adbShellCommand` config flag, so the system has finished boo
 the accessibility service is enabled.
 
 Audio and TalkBack are always enabled &mdash; there are no toggles to configure. The session is
-not auto-started &mdash; the embed shows "Tap to Play" and the user starts it when ready. As soon
-as the session starts the embed iframe is focused (via `iframe.focus()`), so the device's arrow
-keys, Enter, etc. are routed to the device out of the box &mdash; the user can navigate with the
-keyboard (and TalkBack) without first clicking on the device.
+not auto-started &mdash; the embed shows "Tap to Play" and the user starts it when ready. Once the
+device is running, clicking it gives it keyboard focus, so the physical arrow keys, Enter, etc.
+navigate the app and TalkBack announces each element. The page shows short on-screen instructions
+explaining this &mdash; we let the device handle keyboard input natively rather than intercepting
+keys on the page.
 
 ## :hammer: Getting Started
 
@@ -63,17 +64,13 @@ const config = {
 };
 ```
 
-### Focusing the device on session start
+### Navigating with the keyboard
 
-Keyboard input only reaches the device once the embed iframe has focus. As soon as the
-session starts the page focuses the iframe so the arrow keys work immediately:
-
-```js
-client.on("session", async session => {
-    document.querySelector("#appetize").focus();
-    // ...
-});
-```
+Keyboard input only reaches the device once the embed (a cross-origin iframe) has focus, which
+happens when the user clicks the device. Rather than trying to force focus from the page &mdash;
+which fights the browser and the embed &mdash; the page shows short instructions telling the user
+to click the phone and then use the arrow keys and `Enter`. Once the device has focus the physical
+keys are forwarded to it natively and TalkBack announces each focused element.
 
 ### Optionally passing an Android public key
 

--- a/audio_talkback_experience/css/styles.css
+++ b/audio_talkback_experience/css/styles.css
@@ -95,6 +95,12 @@ body {
     -webkit-text-size-adjust: 100%;
 }
 
+/* The body is focused programmatically (tabindex="-1") so key events reach the page;
+   don't show a focus outline for it. */
+body:focus {
+    outline: none;
+}
+
 p {
     margin-top: 0;
     margin-bottom: 1rem;
@@ -110,30 +116,31 @@ h2,
     margin-bottom: 1rem;
 }
 
-/* Keyboard hint — an animated keycap cluster that shows the experience is keyboard-driven */
+/* Step-by-step instructions for navigating the device with the keyboard. */
 
-.kbd-hint {
-    display: flex;
-    align-items: center;
-    gap: 1.5rem;
-    margin-top: 2rem;
+.kbd-steps {
+    margin: 1.5rem 0 0;
+    padding-left: 3.25rem;
+    color: #444;
+    font-size: 0.95rem;
+    line-height: 1.9;
 }
 
-.kbd-cluster {
-    flex: 0 0 auto;
-    display: grid;
-    grid-template-columns: repeat(3, 2.4rem);
-    grid-template-rows: repeat(2, 2.4rem);
-    gap: 0.4rem;
-    grid-template-areas:
-        ".    up    ."
-        "left down  right";
+.kbd-steps li {
+    padding-left: 0.35rem;
 }
 
-.kbd-up    { grid-area: up; }
-.kbd-left  { grid-area: left; }
-.kbd-down  { grid-area: down; }
-.kbd-right { grid-area: right; }
+.kbd-steps li::marker {
+    color: var(--bs-primary);
+    font-weight: 700;
+}
+
+.kbd-note {
+    margin-top: 0.75rem;
+    color: #888;
+    font-size: 0.85rem;
+    font-style: italic;
+}
 
 .kbd {
     display: inline-flex;
@@ -141,43 +148,21 @@ h2,
     justify-content: center;
     font-family: var(--bs-font-sans-serif);
     font-weight: 600;
-    font-size: 1.1rem;
     color: var(--bs-primary);
     background: var(--bs-foreground);
     border: 1px solid #e2e6ee;
-    border-radius: 0.55rem;
-    box-shadow: 0 2px 0 #d3d9e4, 0 4px 8px rgba(4, 12, 31, 0.10);
+    border-radius: 0.4rem;
     user-select: none;
 }
 
-.kbd-cluster .kbd {
-    width: 2.4rem;
-    height: 2.4rem;
-}
-
+/* Inline keycaps used within the instruction text. */
 .kbd-inline {
-    padding: 0.05rem 0.5rem;
-    font-size: 0.8rem;
-    vertical-align: baseline;
+    min-width: 1.6rem;
+    height: 1.6rem;
+    padding: 0 0.4rem;
+    font-size: 0.85rem;
+    vertical-align: middle;
     box-shadow: 0 1px 0 #d3d9e4, 0 2px 4px rgba(4, 12, 31, 0.08);
-}
-
-.kbd-hint-copy {
-    display: flex;
-    flex-direction: column;
-    gap: 0.25rem;
-}
-
-.kbd-hint-lead {
-    font-weight: 700;
-    color: var(--h2-color);
-    font-size: 1.05rem;
-}
-
-.kbd-hint-sub {
-    color: #666;
-    font-size: 0.9rem;
-    line-height: 1.5;
 }
 
 #appActions {

--- a/audio_talkback_experience/js/core.js
+++ b/audio_talkback_experience/js/core.js
@@ -39,16 +39,19 @@ async function initClient(sessionConfig) {
                 window.session = null;
             });
 
-            // Focus the embed iframe so keyboard input (e.g. the arrow keys) is routed to the
-            // device without the user having to click it first. Focusing at "session" alone is
-            // too early — the player isn't interactive yet — so we (re)focus once the first
-            // frame arrives and again once the device is fully ready.
-            session.on("firstFrameReceived", focusDevice);
-
             // TalkBack is always enabled at runtime, once the device is ready.
             await enableTalkBack(session);
-            focusDevice();
+
+            // Now that the device is ready, focus the page so key presses are captured and
+            // forwarded to the device (see observeKeyboard / focusPage). This must run *after*
+            // the device is ready — during startup the embed keeps reclaiming focus, so an
+            // earlier focus wouldn't stick.
+            focusPage();
         });
+
+        // Start the session automatically (rather than waiting for a "Tap to Play" click).
+        console.log('starting session…');
+        await window.client.startSession();
     } catch (error) {
         console.error(error);
     }
@@ -82,23 +85,51 @@ async function enableTalkBack(session) {
 }
 
 /**
- * Focuses the embed iframe so the browser routes keyboard events to the device. With the iframe
- * focused the device's arrow keys, Enter, etc. work immediately &mdash; handy for navigating with
- * TalkBack without first clicking on the device.
+ * Navigation keys we forward from the page to the device. `session.keypress` maps each of these
+ * to the matching device key, so a TalkBack user can move around with the keyboard.
  */
-function focusDevice() {
-    const iFrame = document.querySelector(appetizeIframeName);
-    if (!iFrame) {
-        return;
-    }
-    // Defer to the next frame so focus lands after the embed's own focus handling has run,
-    // otherwise it can be stolen back and the arrow keys won't reach the device.
-    requestAnimationFrame(() => iFrame.focus({ preventScroll: true }));
+const forwardedKeys = new Set([
+    'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Enter', 'Tab', 'Backspace'
+]);
+
+/**
+ * Forwards keyboard navigation to the device. The embed runs in a cross-origin iframe, so key
+ * events only reach the device once something inside that iframe has focus. Instead of relying on
+ * that, we listen for key presses on this page and relay them to the device via `session.keypress`.
+ *
+ * Note: `session.keypress` uses the action recorder under the hood, so it requires the session's
+ * `record` option to be enabled. It currently works because that defaults to `true`.
+ */
+function observeKeyboard() {
+    window.addEventListener('keydown', async (event) => {
+        if (!window.session || !forwardedKeys.has(event.key)) {
+            return;
+        }
+        // Prevent the arrow keys from scrolling the page / Tab from moving page focus.
+        event.preventDefault();
+        try {
+            await window.session.keypress(event.key, { shift: event.shiftKey });
+        } catch (error) {
+            console.warn(`Failed to forward key "${event.key}" to the device`, error);
+        }
+    });
 }
 
 /**
- * Applies the launch config to the embed. Audio output and TalkBack are always enabled.
- * The session is NOT auto-started — the user starts it by clicking "Tap to Play".
+ * Gives this page keyboard focus so the listener in observeKeyboard fires without the user
+ * clicking first. The body isn't focusable by default, so we make it focusable and focus it.
+ */
+function focusPage() {
+    if (!document.body) {
+        return;
+    }
+    document.body.setAttribute('tabindex', '-1');
+    document.body.focus({ preventScroll: true });
+}
+
+/**
+ * Applies the launch config to the embed and starts a session. Audio output and TalkBack are
+ * always enabled, and the session auto-starts (see initClient).
  * @returns {Promise<void>} A promise that resolves when the config is applied.
  */
 async function updateSession() {
@@ -114,7 +145,6 @@ async function updateSession() {
             scale: config.scale,
             toast: config.toast,
             orientation: 'portrait',
-            record: false,
             // (Android only) Audio playback is always enabled on the device.
             audio: true,
             // Device volume, a number from 0 to 1.
@@ -127,8 +157,7 @@ async function updateSession() {
         console.log(sessionConfig);
 
         if (!window.client) {
-            // Initialise the client with the config but don't start a session — the embed
-            // shows "Tap to Play" and the user starts the session when they're ready.
+            // Initialise the client and auto-start the session (see initClient).
             await initClient(sessionConfig);
         } else {
             // Update the config for the next session the user starts (ends any active session).
@@ -143,5 +172,6 @@ async function updateSession() {
 
 document.addEventListener("DOMContentLoaded", async function () {
     initAnimations();
+    observeKeyboard();
     await updateSession();
 });

--- a/audio_talkback_experience/launch.html
+++ b/audio_talkback_experience/launch.html
@@ -42,25 +42,26 @@
                     TalkBack Experience
                 </h2>
                 <p class="ps-8" data-aos="fade-right">
-                    Hear how your app feels for someone using a screen reader. Tap the phone to
-                    start and turn up your volume &mdash; then steer the whole thing from your
-                    keyboard while <strong>TalkBack</strong> reads each screen aloud.
+                    Hear how your app feels for someone using a screen reader. The device starts
+                    automatically with audio and <strong>TalkBack</strong> on &mdash; turn up your
+                    volume and it reads each screen aloud as you explore.
                 </p>
-                <div class="kbd-hint ps-8 mb-5" data-aos="fade-right">
-                    <div class="kbd-cluster" aria-hidden="true">
-                        <span class="kbd kbd-up">&uarr;</span>
-                        <span class="kbd kbd-left">&larr;</span>
-                        <span class="kbd kbd-down">&darr;</span>
-                        <span class="kbd kbd-right">&rarr;</span>
-                    </div>
-                    <div class="kbd-hint-copy">
-                        <span class="kbd-hint-lead">Navigate with your keyboard</span>
-                        <span class="kbd-hint-sub">
-                            Arrow keys move between elements, <span class="kbd kbd-inline">Enter</span> taps.
-                            No need to click the phone first &mdash; it's ready the moment it loads.
-                        </span>
-                    </div>
-                </div>
+                <ol class="kbd-steps ps-8 mb-5" data-aos="fade-right">
+                    <li>
+                        Use the arrow keys
+                        <span class="kbd kbd-inline">&uarr;</span>
+                        <span class="kbd kbd-inline">&darr;</span>
+                        <span class="kbd kbd-inline">&larr;</span>
+                        <span class="kbd kbd-inline">&rarr;</span>
+                        to move between elements, and <span class="kbd kbd-inline">Enter</span> to select.
+                    </li>
+                    <li>TalkBack announces each element as you land on it.</li>
+                    <li>You can also tap or type directly on the device anytime.</li>
+                </ol>
+                <p class="kbd-note ps-8" data-aos="fade-right">
+                    Keys not working? Click the device or anywhere on this page once to activate
+                    keyboard navigation.
+                </p>
             </div>
             <div class="col-md-5 col-lg-6 mt-3 text-center">
                 <div>

--- a/js/samples.js
+++ b/js/samples.js
@@ -33,8 +33,8 @@ const samples = [
         sourceCode: "https://github.com/appetizeio/appetize-samples/tree/main/device_configuration_experience_variant_2"
     },
     {
-        title: "Audio & TalkBack Experience",
-        description: "This sample page demonstrates how to enable audio output and Google's TalkBack screen reader on Android by passing the audio config flag and running adb shell commands via the adbShellCommand config flag.",
+        title: "TalkBack Experience",
+        description: "This sample page demonstrates how to enable audio output and Google's TalkBack screen reader on Android by passing the audio config flag and running adb shell commands via session.adbShellCommand once the device is ready.",
         tags: ["demo engineering", "support", "testing"],
         sample: "audio_talkback_experience/launch.html",
         sourceCode: "https://github.com/appetizeio/appetize-samples/tree/main/audio_talkback_experience"


### PR DESCRIPTION
## Summary
Reworks the TalkBack sample so it demonstrates the accessibility experience with no configuration fiddling.

- **Always-on audio + TalkBack** — removed the toggles and the *Open Sample Video* button.
- **Auto-start** the session via `client.startSession()` (no "Tap to Play").
- **Keyboard navigation** — forward arrow keys / Enter / Tab / Backspace from the page to the device via `session.keypress`, and focus the page once the device is ready so the keys work without clicking. A muted on-page note tells users to click the device or page if focus didn't land.
- **Friendlier instructions** — plain-language, numbered steps instead of technical toggles.
- **Card rename** — "Audio & TalkBack Experience" → "TalkBack Experience" in `js/samples.js`, with an updated description.

## Verified
Driven end-to-end against the real Appetize backend (headless Chrome): session auto-starts, page holds focus (`activeElement` = body, no click), and ArrowDown moves the TalkBack focus and scrolls the app.

## Notes
- `session.keypress` uses the action recorder, so key forwarding depends on the session's `record` option being enabled (currently the SDK default). If that default becomes `false`, this sample must set `record: true` or forwarding breaks. Flagged in a code comment.
- Browser autoplay policy may keep device audio muted until the first user interaction, since the session auto-starts without a gesture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)